### PR TITLE
[FIX] Dynamic server usage: headers

### DIFF
--- a/src/app/api/invoice/last/route.ts
+++ b/src/app/api/invoice/last/route.ts
@@ -1,8 +1,8 @@
 import { getServerSession } from 'next-auth'
 import { db } from '@/lib/db'
 import { authOptions } from '../../auth/[...nextauth]/route'
-import { error } from 'console'
 
+export const dynamic = 'force-dynamic'
 export async function GET() {
   try {
     const session = await getServerSession(authOptions)
@@ -28,7 +28,7 @@ export async function GET() {
 
     if (!org?.organizations?.id) {
       console.error('Error:', 'Organization Not Found')
-      return Response.json({ ok: false, data: error, status: 404 })
+      return Response.json({ ok: false, data: null, status: 404 })
     }
 
     const response = await db.invoice.findFirst({

--- a/src/app/api/invoice/overview/route.ts
+++ b/src/app/api/invoice/overview/route.ts
@@ -2,6 +2,8 @@ import { getServerSession } from 'next-auth'
 import { db } from '@/lib/db'
 import { authOptions } from '../../auth/[...nextauth]/route'
 import { Invoice } from '@prisma/client'
+
+export const dynamic = 'force-dynamic'
 export async function GET() {
   try {
     const session = await getServerSession(authOptions)
@@ -110,7 +112,7 @@ export async function GET() {
     })
   } catch (error) {
     console.error('Error retrieving invoice statistics:', error)
-    return Response.json({ ok: false, data: error, status: 500 })
+    return Response.json({ ok: false, data: null, status: 500 })
   }
 
   function calculatePercentageChange(


### PR DESCRIPTION
DynamicServerError: Dynamic server usage: Page couldn't be rendered statically because it used `headers`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error at staticGenerationBailout (/vercel/path0/.next/server/chunks/657.js:1:1635) at headers (/vercel/path0/.next/server/chunks/374.js:30:30209) at getServerSession (/vercel/path0/.next/server/chunks/374.js:30:20722) at GET (/vercel/path0/.next/server/app/api/invoice/last/route.js:1:1260) at /vercel/path0/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:14:39715 at /vercel/path0/node_modules/next/dist/server/lib/trace/tracer.js:121:36 at NoopContextManager.with (/vercel/path0/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057) at ContextAPI.with (/vercel/path0/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516) at NoopTracer.startActiveSpan (/vercel/path0/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18086) at ProxyTracer.startActiveSpan (/vercel/path0/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18847) { digest: 'DYNAMIC_SERVER_USAGE'