### PR TITLE
[FIX] Dynamic server usage: Page couldn't be rendered statically

### DIFF
--- a/src/app/api/crons/invoices/update-status/route.ts
+++ b/src/app/api/crons/invoices/update-status/route.ts
@@ -1,5 +1,6 @@
 import { db } from '@/lib/db'
 
+export const dynamic = 'force-dynamic'
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)


### PR DESCRIPTION
because it used `request.url`